### PR TITLE
chore: HL AFA 2025 config updates (2025-11)

### DIFF
--- a/configs/etf2l_9v9_5cp.cfg
+++ b/configs/etf2l_9v9_5cp.cfg
@@ -1,10 +1,10 @@
 mp_maxrounds 0
 mp_timelimit 30
 mp_windifference 5
-mp_winlimit 0
+mp_winlimit 5
 mp_timelimit_improved 0
 mp_timelimit_improved_visibility 0
-round_time_override -1
+round_time_override 300
 sm_improvedtimers_chat 1
 
 exec etf2l_9v9

--- a/configs/etf2l_9v9_koth_bo5.cfg
+++ b/configs/etf2l_9v9_koth_bo5.cfg
@@ -1,0 +1,12 @@
+mp_maxrounds 0
+mp_timelimit 0
+mp_windifference 0
+mp_winlimit 3
+mp_timelimit_improved 0
+mp_timelimit_improved_visibility 0
+round_time_override -1
+sm_improvedtimers_chat 1
+
+exec etf2l_9v9
+say HL KOTH Bo5 config has been loaded.
+say ******************************************************************


### PR DESCRIPTION
Updated etf2l_9v9_5cp.cfg and added etf2l_9v9_koth_bo5.cfg for HL AFA 2025

- etf2l_9v9_5cp.cfg: mp_winlimit 5 and round_time_override 300 (5 min round timer)
- etf2l_9v9_koth_bo5.cfg: mp_winlimit 3 for Bo5 KoTH without halftime breaks